### PR TITLE
Label commit in README and benchmark output

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,3 @@
-
 #+TITLE: Shoplifter
 
 Steals a Sombrero from HiRep.

--- a/README.org
+++ b/README.org
@@ -1,3 +1,4 @@
+
 #+TITLE: Shoplifter
 
 Steals a Sombrero from HiRep.
@@ -27,7 +28,9 @@ some of these steps might fail.
 3. Clone as "thin" version of Sombrero
    (where "thin" means without most of LibHR,
    that will be stolen from HiRep);
-4. "Graft" Sombrero onto HiRep,
+4. Label the Sombrero README and benchmark output with the commit ID of the
+   Sombrero, HiRep, and shoplifter versions used to generate it.
+5. "Graft" Sombrero onto HiRep,
    i.e., copy some files from Sombrero into HiRep
    - sombrero/sombrero directory
    - Include/suN.h
@@ -36,14 +39,14 @@ some of these steps might fail.
    - Include/libhr_defines_interface.h
    - Include/suN_types.h
    This is done to build ASTs and callgraphs starting from Sombrero's ~main()~ function;
-5. Clone pycparser (to use [[https://github.com/eliben/pycparser/tree/master/utils/fake_libc_include][fake_libc_include]] as recommended);
-6. Analyse callgraph with sombrero and LibHR, find the useful source files;
-7. Copy and clean the useful sources to the "thin Sombrero" repository, filtering out the unused functions;
-8. Copy the makefiles to the "thin Sombrero" repository (not overwriting the ones that are already there); 
-9. Copy and clean the useful headers to the "thin Sombrero" repository;
-10. Copy to the "thin Sombrero" repository other manually listed files that for some reason were not detected;
-11. Clean the macros in the "thin Sombrero" repository (which is not that thin anymore), in place.
-12. Package sombrero in a ~tar.gz~ file.
+6. Clone pycparser (to use [[https://github.com/eliben/pycparser/tree/master/utils/fake_libc_include][fake_libc_include]] as recommended);
+7. Analyse callgraph with sombrero and LibHR, find the useful source files;
+8. Copy and clean the useful sources to the "thin Sombrero" repository, filtering out the unused functions;
+9. Copy the makefiles to the "thin Sombrero" repository (not overwriting the ones that are already there);
+10. Copy and clean the useful headers to the "thin Sombrero" repository;
+11. Copy to the "thin Sombrero" repository other manually listed files that for some reason were not detected;
+12. Clean the macros in the "thin Sombrero" repository (which is not that thin anymore), in place.
+13. Package sombrero in a ~tar.gz~ file.
 
 Note: all the steps are defined in [[file:lib.sh][lib.sh]].
 

--- a/lib.sh
+++ b/lib.sh
@@ -72,6 +72,61 @@ clone_sombrero(){
     git clone --depth=1 ${SOMBRERO_REMOTE} --branch ${SOMBRERO_REMOTE_BRANCH} ${SOMBRERO}
 }
 # 4
+set_version_information(){
+    local HIREP=$1
+    local SOMBRERO=$2
+    local SHOPLIFTER=$3
+
+    get_commit_id_for_directory() {
+        local DIRNAME=$1
+        local GIT_CMD="git -C ${DIRNAME} rev-parse --short HEAD"
+        if ${GIT_CMD} >/dev/null 2>&1; then
+            local ID=$( ${GIT_CMD} )
+            if ! git -C ${DIRNAME} diff --exit-code >/dev/null; then
+                local ID="${ID} (UNCOMMITTED CHANGES)"
+                local RETVAL=1
+            else
+                local RETVAL=0
+            fi
+        else
+            local ID="UNKNOWN"
+            local RETVAL=2
+        fi
+        echo ${ID}
+        return ${RETVAL}
+    }
+    get_commit_url() {
+        local REPO="$1"
+        local DIRNAME="$2"
+        if get_commit_id_for_directory ${DIRNAME} >/dev/null; then
+            echo ${REPO}/tree/$( get_commit_id_for_directory ${DIRNAME} )
+        else
+            echo ${REPO}
+        fi
+    }
+    portable_sed_in_place() {
+        local EXPR="$1"
+        local FILE="$2"
+        local TMP_FILE="$( mktemp XXXXXXXX )"
+        sed "${EXPR}" "${FILE}" > "${TMP_FILE}"
+        mv "${TMP_FILE}" "${FILE}"
+    }
+    local HIREP_COMMIT_ID="$(get_commit_id_for_directory ${HIREP})"
+    local SOMBRERO_COMMIT_ID="$(get_commit_id_for_directory ${SOMBRERO})"
+    local SHOPLIFTER_COMMIT_ID="$(get_commit_id_for_directory ${SHOPLIFTER})"
+    local HIREP_URL="$(get_commit_url https://github.com/sa2c/HiRep ${HIREP})"
+    local SOMBRERO_URL="$(get_commit_url https://github.com/sa2c/SOMBRERO ${SOMBRERO})"
+    local SHOPLIFTER_URL="$(get_commit_url https://github.com/mmesiti/shoplifter ${SHOPLIFTER})"
+    for FILE in ${SOMBRERO}/README.md ${SOMBRERO}/sombrero/sombrero.c; do
+        portable_sed_in_place "s|{{hirep_commit}}|${HIREP_COMMIT_ID}|" ${FILE}
+        portable_sed_in_place "s|{{sombrero_commit}}|${SOMBRERO_COMMIT_ID}|" ${FILE}
+        portable_sed_in_place "s|{{shoplifter_commit}}|${SHOPLIFTER_COMMIT_ID}|" ${FILE}
+        portable_sed_in_place "s|{{hirep_url}}|${HIREP_URL}|" ${FILE}
+        portable_sed_in_place "s|{{sombrero_url}}|${SOMBRERO_URL}|" ${FILE}
+        portable_sed_in_place "s|{{shoplifter_url}}|${SHOPLIFTER_URL}|" ${FILE}
+    done
+}
+# 5
 copy_sombrero_files(){
     local HIREP=$1
     local SOMBRERO=$2
@@ -100,20 +155,20 @@ copy_sombrero_files(){
     done 
 
 }
-# 5
+# 6
 clone_pycparser(){
     local PYCPARSER=$1
     echo -e "${BOLD}Cloning $PYCPARSER${NORMAL}"
     git clone --depth=1 ${PYCPARSER_REMOTE} $PYCPARSER
 }
-# 6
+# 7
 analyse_callgraph(){
     local HIREP=$1
     local PYCPARSER=$2
     echo -e "${BOLD}Analysing Callgraph in $HIREP${NORMAL}"
     python3 $FFMODULE/main.py $FFMODULE/cpp_flags.yaml $HIREP $PYCPARSER
 }
-# 7 
+# 8
 copy_and_clean_selected_sources(){
     # TODO: maybe use a flat directory instead?    
     local HIREP=$1
@@ -127,7 +182,7 @@ copy_and_clean_selected_sources(){
     done
 
 }
-# 8
+# 9
 copy_makefiles(){
     # Since we're not using a flat directory,
     # we need to also copy the makefiles
@@ -152,7 +207,7 @@ copy_makefiles(){
         fi
     done
 }
-# 9
+# 10
 copy_selected_headers(){
     local FILELIST=$1
     local SOMBRERO=$2
@@ -165,7 +220,7 @@ copy_selected_headers(){
         python3 $FFMODULE/filter_header.py $FILE $NEWFILE $UNUSED_FUNCTIONS
     done 
 }
-#10 
+# 11
 copy_additional_files(){
     local FILELIST=$1
     local HIREP=$2
@@ -181,14 +236,14 @@ copy_additional_files(){
         )
     done
 }
-#11
+# 12
 clean_macros(){
     local SOMBRERO=$1
     echo -e "${BOLD}Cleaning macros in $SOMBRERO${NORMAL}"
     $MACROMODULE/replace_macros.sh $SOMBRERO
 }
 
-#12
+# 13
 package(){
     local SOMBRERO=$1
     local OUTPUT=sombrero.tar.gz

--- a/remotes.html.sh
+++ b/remotes.html.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export HIREP_REMOTE=https://github.com/sa2c/HiRep
 export HIREP_REMOTE_BRANCH=spn-swansea-merge
 
-export SOMBRERO_REMOTE=https://github.com/mmesiti/sombrero.git
+export SOMBRERO_REMOTE=https://github.com/sa2c/sombrero.git
 export SOMBRERO_REMOTE_BRANCH=thin
 
 export PYCPARSER_REMOTE=https://github.com/eliben/pycparser.git

--- a/remotes.ssh.sh
+++ b/remotes.ssh.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export HIREP_REMOTE=git@github.com:sa2c/HiRep
 export HIREP_REMOTE_BRANCH=spn-swansea-merge
 
-export SOMBRERO_REMOTE=git@github.com:mmesiti/sombrero.git
+export SOMBRERO_REMOTE=git@github.com:sa2c/sombrero.git
 export SOMBRERO_REMOTE_BRANCH=thin
 
 export PYCPARSER_REMOTE=git@github.com:eliben/pycparser.git

--- a/shoplifter.sh
+++ b/shoplifter.sh
@@ -10,22 +10,24 @@ generate_headers $HIREP
 # 3
 clone_sombrero $SOMBRERO
 # 4
-copy_sombrero_files $HIREP $SOMBRERO  
+set_version_information $HIREP $SOMBRERO $SCRIPT_LOCATION
 # 5
-clone_pycparser $PYCPARSER
+copy_sombrero_files $HIREP $SOMBRERO
 # 6
+clone_pycparser $PYCPARSER
+# 7
 analyse_callgraph $HIREP $PYCPARSER
-# 7 
-copy_and_clean_selected_sources $HIREP $SOMBRERO  
 # 8
-copy_makefiles $HIREP $SOMBRERO  
+copy_and_clean_selected_sources $HIREP $SOMBRERO
 # 9
+copy_makefiles $HIREP $SOMBRERO
+# 10
 copy_selected_headers used_headers.txt $SOMBRERO  all_unused_functions.txt
-#10 
+# 11
 copy_additional_files $SCRIPT_LOCATION/additional_files_to_copy.txt $HIREP $SOMBRERO
-#11
+# 12
 clean_macros $SOMBRERO
-#12
+# 13
 package $SOMBRERO
 
 echo "Finished."

--- a/shoplifter.sh
+++ b/shoplifter.sh
@@ -5,12 +5,14 @@ source $SCRIPT_LOCATION/lib.sh
 
 # 1
 clone_hirep $HIREP
+HIREP_COMMIT_ID="$(get_commit_id_for_directory ${HIREP})"
+HIREP_URL="$(get_commit_url https://github.com/sa2c/HiRep ${HIREP})"
 # 2
 generate_headers $HIREP
 # 3
 clone_sombrero $SOMBRERO
 # 4
-set_version_information $HIREP $SOMBRERO $SCRIPT_LOCATION
+set_version_information $HIREP $SOMBRERO $SCRIPT_LOCATION $HIREP_COMMIT_ID $HIREP_URL
 # 5
 copy_sombrero_files $HIREP $SOMBRERO
 # 6


### PR DESCRIPTION
When combined with the most recent version of the thin SOMBRERO, this generates a version of SOMBRERO that labels both the README and the SOMBRERO output with the commit ID (and in the README a link to the GitHub repository at that commit) of shoplifter, HiRep, and thin SOMBRERO used to generate it. (If any of these is not known, then "UNKNOWN" is used instead, and if there are local changes to any of these repositories, then "UNCOMMITTED CHANGES" is appended to the commit ID. In both cases, the link is then to the root of the GitHub repository rather than to any specific commit.)